### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ The UMD and style files are also available on [unpkg](https://unpkg.com):
 Available on [JSDelivr](https://www.jsdelivr.com/)
 
 ```html
-<link href="https://cdn.jsdelivr.net/prelodr/latest/prelodr.min.css">
-<script src="https://cdn.jsdelivr.net/prelodr/latest/prelodr.min.js"></script>
+<link href="https://cdn.jsdelivr.net/npm/prelodr@latest/dist/prelodr.min.css">
+<script src="https://cdn.jsdelivr.net/npm/prelodr@latest/dist/prelodr.min.js"></script>
 ```
 Available on [cdnjs](https://cdnjs.com/libraries/prelodr)
 


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/prelodr.

Feel free to ping me if you have any questions regarding this change.